### PR TITLE
Update pint version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ oslo.log>=3.36.0 # Apache-2.0
 oslo.serialization!=2.19.1,>=2.18.0 # Apache-2.0
 oslo.service!=1.28.1,>=1.24.0 # Apache-2.0
 oslo.utils>=3.33.0 # Apache-2.0
-Pint>=0.5 # BSD
+Pint>=0.19.2 # BSD
 psutil>=3.2.2 # BSD
 pyudev>=0.18 # LGPLv2.1+
 requests>=2.14.2 # Apache-2.0


### PR DESCRIPTION
```
2022-09-16 21:48:14.131 | ERROR: Cannot install ironic-python-agent==6.0.1.dev7 because these package versions have conflicting dependencies.
2022-09-16 21:48:14.131 | 
2022-09-16 21:48:14.131 | The conflict is caused by:
2022-09-16 21:48:14.131 |     ironic-python-agent 6.0.1.dev7 depends on Pint>=0.5
2022-09-16 21:48:14.131 |     The user requested (constraint) pint===0.19.2
2022-09-16 21:48:14.131 | 
```